### PR TITLE
GS-1244 F2F-Booking-not-transferred-from-temp-to-payroll

### DIFF
--- a/classes/local/default_db_config.php
+++ b/classes/local/default_db_config.php
@@ -278,6 +278,12 @@ class default_db_config {
                 'userfield' => ['userid'],
                 'otherfields' => ['forum'],
             ],
+            'facetoface_signups' => [
+                // For index 'userid-sessionid'.
+                // Type of index: unique; type of matching: by %user%-related column name.
+                'userfield' => ['userid'],
+                'otherfields' => ['sessionid'],
+            ],
             'h5pactivity_attempts' => [
                 // For index 'mdl_h5paatte_h5puseatt_uix'.
                 // Type of index: unique; type of matching: by %user%-related column name.


### PR DESCRIPTION
## Description:
<!-- Describe your changes in detail / numbered list of distinct changes for reference -->
The Mergeusers plugin fails to transfer face to face session bookings from temporary accounts to payroll accounts because the facetoface_signups table lacks the compound index required by the generic table merger.

Change

Adds a compound index on userid and sessionid to allow the generic merger to correctly match and transfer records during the merge process.

Testing

Basic testing was performed. Face to face bookings were successfully transferred from temporary accounts to payroll accounts after the change. Verification was completed through both the UI and the facetoface_signups database table.

After Merging Session booking page
<img width="906" height="172" alt="image" src="https://github.com/user-attachments/assets/4dfd8645-3075-4e4e-baad-4a93068f8a07" />

Before merging facetofacesigups DB
<img width="704" height="198" alt="image" src="https://github.com/user-attachments/assets/25a50a53-280d-49b2-b6f2-081f7173d440" />

Before Merging Session booking page
<img width="839" height="101" alt="image" src="https://github.com/user-attachments/assets/14bedafa-081c-4436-8adb-444861b368ee" />

After merging facetofacesigups DB
<img width="666" height="181" alt="image" src="https://github.com/user-attachments/assets/0d3ff217-6c1b-4c89-8933-cab13962f275" />


## Checklist before requesting a review:
<!-- Remove non-applicable items e.g. epic sub-issue points -->
<!-- Add an 'x' inside the brackets to check the item -->

- [x] I have performed a self review of my code.
- [x] My code follows the [Moodle Coding Style](https://moodledev.io/general/development/policies/codingstyle).
- [x] Version numbers have been updated.
- [x] Code has been commented, particularly in hard-to-understand areas.

